### PR TITLE
Don't watch node modules

### DIFF
--- a/karma.conf.coffee
+++ b/karma.conf.coffee
@@ -80,6 +80,10 @@ module.exports = (config) ->
         '.json'
       ]
 
+    watchify:
+      # ignore all node modules except of local modules
+      ignoreWatch: ['**/node_modules/**', '!**/node_modules/local_modules/**']
+
     # test results reporter to use
     # possible values: 'dots', 'progress'
     # available reporters: https:#npmjs.org/browse/keyword/karma-reporter


### PR DESCRIPTION
Before, watchify was watching **all** node modules, so that we could pickup changes to local modules (which are required via the node_modules directory). 

This adds a custom glob pattern that watches only local modules, but nothing else. This speeds up the initial build a bit.
